### PR TITLE
feat: changed update intent callback return signature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@juspay-tech/react-hyper-js",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@juspay-tech/react-hyper-js",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@rescript/core": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juspay-tech/react-hyper-js",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "main": "dist/bundle.js",
   "files": [
     "dist/",

--- a/src/Context.res
+++ b/src/Context.res
@@ -60,7 +60,7 @@ type rec elementsType = {
   getElement: string => option<OrcaJs.paymentElement>,
   fetchUpdates: unit => Promise.t<JSON.t>,
   create: (string, JSON.t) => OrcaJs.paymentElement, // return a react component instead by doing new Payment Element.
-  updateIntent: (unit => promise<string>) => promise<JSON.t>,
+  updateIntent: (unit => promise<JSON.t>) => promise<JSON.t>,
 }
 
 type rec paymentMethodsManagementElementsType = {
@@ -232,7 +232,7 @@ let paymentMethodsManagementElementsOptionObjMapper = (options: JSON.t) => {
 
 type paymentSessionContextType = {
   getCustomerSavedPaymentMethods: unit => promise<JSON.t>,
-  updateIntent: (unit => promise<string>) => promise<JSON.t>,
+  updateIntent: (unit => promise<JSON.t>) => promise<JSON.t>,
 }
 
 let defaultPaymentSessionContext: paymentSessionContextType = {

--- a/src/OrcaJs.res
+++ b/src/OrcaJs.res
@@ -47,7 +47,7 @@ type element = {
   update: JSON.t => unit,
   fetchUpdates: unit => Promise.t<JSON.t>,
   create: (string, JSON.t) => paymentElement,
-  updateIntent: (unit => promise<string>) => promise<JSON.t>,
+  updateIntent: (unit => promise<JSON.t>) => promise<JSON.t>,
 }
 
 type confirmParams = {return_url: string}
@@ -66,7 +66,7 @@ type getCustomerSavedPaymentMethods = {
 
 type initPaymentSession = {
   getCustomerSavedPaymentMethods: unit => Promise.t<JSON.t>,
-  updateIntent: (unit => promise<string>) => promise<JSON.t>,
+  updateIntent: (unit => promise<JSON.t>) => promise<JSON.t>,
 }
 
 type switchInstance = {


### PR DESCRIPTION
## Type of Change
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD
---
## **Description**
Updated the `updateIntent` function signature across `Context.res` and `OrcaJs.res` to accept a callback typed as `unit => promise<JSON.t>` instead of `unit => promise<string>`, aligning the API contract with the expected behavior.
Changed in:
- `Context.res`: `elementsType.updateIntent` and `paymentSessionContextType.updateIntent`
- `OrcaJs.res`: `element.updateIntent` and `initPaymentSession.updateIntent`
---
## **How did you test it?**
- Ran `npm run re:build` — no build artifact changes, confirming this is a compile-time only change with no runtime impact.
- Verified updated signature is consistent across all four `updateIntent` usages.
---
## **Usage Notes**
- No impact on JavaScript consumers — types are erased at compile time and the JS output is identical.
- ReScript consumers must update `updateIntent` callbacks from `unit => promise<string>` to `unit => promise<JSON.t>` to comply with the updated contract.
- No backward compatibility guaranteed for ReScript consumers.
---
## **Version Update**
- [x] I have bumped the package version in `package.json` following semantic versioning:
  - `x.x.x` for major changes (breaking).
  - `2.3.0` for minor changes (new feature, no breaking changes).
  - `x.x.x` for patch changes (bug fixes, minor improvements).
---
## **Checklist**
- [x] I ran `npm run re:build` and verified the build artifacts.
- [x] I reviewed the code for style, readability, and consistency.
- [ ] I verified the changes are backward compatible (if applicable).
- [ ] I tested this change in a real or simulated consuming project.
- [ ] I updated documentation, README, or usage examples if necessary.
---
## **Screenshots or Logs**
No runtime changes — build output is identical before and after. API contract update is compile-time only.